### PR TITLE
Run tests in parallel

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -6,6 +6,11 @@ on:
     tags:
     - v*
 
+# Only allow one instance of this workflow for each PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,15 +10,16 @@ concurrency:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python }}
+        python-version: |
+          3.9
+          3.10
+          3.11
+          3.12
         allow-prereleases: true
     - run: python -m pip install tox
-    - run: tox -e py
+    - run: tox run-parallel --parallel-no-spinner

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,3 +28,5 @@ jobs:
           tox.ini
     - run: python -m pip install tox
     - run: tox run-parallel --parallel-no-spinner
+      env:
+        FORCE_COLOR: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,5 +21,10 @@ jobs:
           3.11
           3.12
         allow-prereleases: true
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements-dev.txt
+          setup.cfg
+          tox.ini
     - run: python -m pip install tox
     - run: tox run-parallel --parallel-no-spinner

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,11 @@ name: tests
 
 on: [push]
 
+# Only allow one instance of this workflow for each PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39,py310,py311,py312
+envlist = py39,py310,py311,py312,report
 
 [testenv]
 # Install wheels instead of source distributions for faster execution.
@@ -9,6 +9,16 @@ wheel_build_env = .pkg
 
 deps = -rrequirements-dev.txt
 commands =
+  coverage run --parallel-mode -m pytest {posargs:tests}
+
+[testenv:clean]
+skip_install = true
+commands =
   coverage erase
-  coverage run -m pytest {posargs:tests}
+
+[testenv:report]
+skip_install = true
+depends = py39,py310,py311,py312
+commands =
+  coverage combine
   coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 envlist = py39,py310,py311,py312
 
 [testenv]
+# Install wheels instead of source distributions for faster execution.
+package = wheel
+# Share the build environment between tox environments.
+wheel_build_env = .pkg
+
 deps = -rrequirements-dev.txt
 commands =
   coverage erase


### PR DESCRIPTION
- **Build a wheel to share between test run environments**
- **Run coverage in parallel mode**
- **Prevent concurrent test runs**
- **Run tests for all python versions in one job**
- **Cache Python dependencies**
- **Show tox/pytest output in color**
